### PR TITLE
Non zero exit code on outdated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [0.3.0] unreleased
 ### Added
-- osx in travis 
+- osx in travis
+- Flag '-ci' to exit with non-zero exit code when an outdated dependency is found
 ### Removed
 - tip version in travis
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,18 @@ If you want to make your CI pipeline fail
 ```
 go list -u -m -json all | go-mod-outdated -direct -ci
 ```
+### CI pipelines
 
+Using the -ci flag will the make the command exit with none zero code, breaking this way your ci pipelines.
+
+If you want to make your CI pipeline fail if any direct or indirect dependency is outdated use the following:
+```
+go list -u -m -json all | go-mod-outdated -ci
+```
+If you want to make your CI pipeline fail only if a direct dependency is outdated use the following:
+```
+go list -u -m -json all | go-mod-outdated -direct -ci
+```
 ### Help
   
 In order to see details about the usage of the command use the **-h** or **-help** flag

--- a/README.md
+++ b/README.md
@@ -398,3 +398,19 @@ $ go list -u -m -json all | go-mod-outdated -update -direct
 | golang.org/x/sync                  | v0.0.0-20180314180146-1d60e4601c6f   | v0.0.0-20190412183630-56d357773e84 | true   | true             |
 +------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
 ```
+### Table view of go list -u -m -json all command using go-mod-outdated (with -ci flag, only direct dependencies with updates)
+
+```
+$ go list -u -m -json all | go-mod-outdated -update -direct -ci
++------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
+|               MODULE               |               VERSION                |            NEW VERSION             | DIRECT | VALID TIMESTAMPS |
++------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
+| github.com/BurntSushi/toml         | v0.0.0-20170626110600-a368813c5e64   | v0.3.1                             | true   | true             |
+| github.com/PuerkitoBio/purell      | v1.1.0                               | v1.1.1                             | true   | true             |
+| github.com/alecthomas/chroma       | v0.6.0                               | v0.6.3                             | true   | true             |
+...
+| golang.org/x/sync                  | v0.0.0-20180314180146-1d60e4601c6f   | v0.0.0-20190412183630-56d357773e84 | true   | true             |
++------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
+$ echo $?
+1
+```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ If you want to see only the direct depedencies that have updates run
 go list -u -m -json all | go-mod-outdated -update -direct 
 ```
 
+If you want to make your CI pipeline fail
+
+```
+go list -u -m -json all | go-mod-outdated -direct -ci
+```
+
 ### Help
   
 In order to see details about the usage of the command use the **-h** or **-help** flag
@@ -86,6 +92,8 @@ Usage of go-mod-outdated:
         List only direct modules
   -update
         List only modules with updates
+  -ci
+        Exit with non-zero exit code when outdated dependencies are found
 ```
 
 ### Shortcut

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,6 +11,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
+var OsExit = os.Exit
+
 // Run converts the the json output of go list -u -m -json all to table format
 func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) error {
 	var modules []mod.Module
@@ -24,7 +26,7 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) erro
 			if err == io.EOF {
 				found := renderTable(out, mod.FilterModules(modules, update, direct))
 				if found && exitWithNonZero {
-					os.Exit(1)
+					OsExit(1)
 				}
 				return nil
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -39,7 +39,7 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) erro
 
 func hasOutdated(filteredModules []mod.Module) bool {
 	for m := range filteredModules {
-		if filteredModules[m].NewVersion() != "" {
+		if filteredModules[m].HasUpdate() {
 			return true
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -24,8 +24,9 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) erro
 
 		if err != nil {
 			if err == io.EOF {
-				found := renderTable(out, mod.FilterModules(modules, update, direct))
-				if found && exitWithNonZero {
+				filteredModules := mod.FilterModules(modules, update, direct)
+				renderTable(out, filteredModules)
+				if hasOutdated(filteredModules) && exitWithNonZero {
 					OsExit(1)
 				}
 				return nil
@@ -36,14 +37,19 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) erro
 	}
 }
 
-func renderTable(writer io.Writer, modules []mod.Module) bool {
-	var found bool
+func hasOutdated(filteredModules []mod.Module) bool {
+	for m := range filteredModules {
+		if filteredModules[m].NewVersion() != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderTable(writer io.Writer, modules []mod.Module) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
 	for k := range modules {
-		if modules[k].NewVersion() != "" {
-			found = true
-		}
 		table.Append([]string{
 			modules[k].Path,
 			modules[k].CurrentVersion(),
@@ -53,5 +59,4 @@ func renderTable(writer io.Writer, modules []mod.Module) bool {
 		})
 	}
 	table.Render()
-	return found
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -56,7 +56,10 @@ func TestRunExitWithNonZero(t *testing.T) {
 	in := bytes.NewBuffer(inBytes)
 
 	if os.Getenv("TEST_EXITCODE") == "1" {
-		_ := runner.Run(in, &out, false, false, true)
+		err := runner.Run(in, &out, false, false, true)
+		if err != nil {
+			t.Errorf("Error should be nil, got %s", err.Error())
+		}
 		return
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=TestRunExitWithNonZero")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -72,7 +72,6 @@ func TestRunExitWithNonZero(t *testing.T) {
 }
 
 func TestRunExitWithNonZeroIndirectsOnly(t *testing.T) {
-	var out bytes.Buffer
 
 	inBytes, _ := ioutil.ReadFile("testdata/update_indirect.txt")
 	in := bytes.NewBuffer(inBytes)
@@ -86,6 +85,7 @@ func TestRunExitWithNonZeroIndirectsOnly(t *testing.T) {
 	}
 
 	runner.OsExit = testExit
+	var out bytes.Buffer
 	err := runner.Run(in, &out, false, true, true)
 	if err != nil {
 		t.Errorf("Error should be nil, got %s", err.Error())

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -69,5 +69,28 @@ func TestRunExitWithNonZero(t *testing.T) {
 	if exp := 1; got != exp {
 		t.Errorf("Expected exit code: %d, got: %d", exp, got)
 	}
+}
 
+func TestRunExitWithNonZeroIndirectsOnly(t *testing.T) {
+	var out bytes.Buffer
+
+	inBytes, _ := ioutil.ReadFile("testdata/update_indirect.txt")
+	in := bytes.NewBuffer(inBytes)
+
+	oldOsExit := runner.OsExit
+	defer func() { runner.OsExit = oldOsExit }()
+
+	var got int
+	testExit := func(code int) {
+		got = code
+	}
+
+	runner.OsExit = testExit
+	err := runner.Run(in, &out, false, true, true)
+	if err != nil {
+		t.Errorf("Error should be nil, got %s", err.Error())
+	}
+	if exp := 0; got != exp {
+		t.Errorf("Expected exit code: %d, got: %d", exp, got)
+	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -49,7 +49,6 @@ func TestRunWithError(t *testing.T) {
 
 }
 
-
 func TestRunExitWithNonZero(t *testing.T) {
 	var out bytes.Buffer
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"io/ioutil"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/psampaz/go-mod-outdated/internal/runner"
@@ -19,7 +21,7 @@ func TestRun(t *testing.T) {
 	outBytes, _ := ioutil.ReadFile("testdata/out.txt")
 	wantOut := bytes.NewBuffer(outBytes)
 
-	err := runner.Run(in, &gotOut, false, false)
+	err := runner.Run(in, &gotOut, false, false, false)
 
 	if err != nil {
 		t.Errorf("Error should be nil, got %s", err.Error())
@@ -38,11 +40,31 @@ func TestRunWithError(t *testing.T) {
 	inBytes, _ := ioutil.ReadFile("testdata/err.txt")
 	in := bytes.NewBuffer(inBytes)
 
-	gotErr := runner.Run(in, &out, false, false)
+	gotErr := runner.Run(in, &out, false, false, false)
 	wantErr := errors.New("unexpected EOF")
 
 	if gotErr.Error() != wantErr.Error() {
 		t.Errorf("Wanted %s, got %s", wantErr, gotErr)
 	}
 
+}
+
+
+func TestRunExitWithNonZero(t *testing.T) {
+	var out bytes.Buffer
+
+	inBytes, _ := ioutil.ReadFile("testdata/in.txt")
+	in := bytes.NewBuffer(inBytes)
+
+	if os.Getenv("TEST_EXITCODE") == "1" {
+		runner.Run(in, &out, false, false, true)
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunExitWithNonZero")
+	cmd.Env = append(os.Environ(), "TEST_EXITCODE=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -56,7 +56,7 @@ func TestRunExitWithNonZero(t *testing.T) {
 	in := bytes.NewBuffer(inBytes)
 
 	if os.Getenv("TEST_EXITCODE") == "1" {
-		runner.Run(in, &out, false, false, true)
+		_ := runner.Run(in, &out, false, false, true)
 		return
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=TestRunExitWithNonZero")

--- a/internal/runner/testdata/update_indirect.txt
+++ b/internal/runner/testdata/update_indirect.txt
@@ -5,73 +5,14 @@
 	"GoMod": "/home/mojo/Code/go/hugo/go.mod"
 }
 {
-	"Path": "github.com/BurntSushi/locker",
-	"Version": "v0.0.0-20171006230638-a6e239ea1c69",
-	"Time": "2017-10-06T23:06:38Z",
-	"Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/locker@v0.0.0-20171006230638-a6e239ea1c69",
-	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/locker/@v/v0.0.0-20171006230638-a6e239ea1c69.mod"
-}
-{
-	"Path": "github.com/BurntSushi/toml",
-	"Version": "v0.0.0-20170626110600-a368813c5e64",
-	"Time": "2017-06-26T11:06:00Z",
-	"Update": {
-		"Path": "github.com/BurntSushi/toml",
-		"Version": "v0.3.1",
-		"Time": "2018-08-15T10:47:33Z"
-	},
-	"Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/toml@v0.0.0-20170626110600-a368813c5e64",
-	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/toml/@v/v0.0.0-20170626110600-a368813c5e64.mod"
-}
-{
-	"Path": "github.com/PuerkitoBio/purell",
-	"Version": "v1.1.0",
-	"Time": "2016-11-15T02:49:42Z",
-	"Update": {
-		"Path": "github.com/PuerkitoBio/purell",
-		"Version": "v1.1.1",
-		"Time": "2019-02-16T21:19:35Z"
-	},
-	"Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.0",
-	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/purell/@v/v1.1.0.mod"
-}
-{
-	"Path": "github.com/PuerkitoBio/urlesc",
-	"Version": "v0.0.0-20170810143723-de5bf2ad4578",
-	"Time": "2017-08-10T14:37:23Z",
-	"Indirect": true,
-	"Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/urlesc/@v/v0.0.0-20170810143723-de5bf2ad4578.mod"
-}
-{
 	"Path": "github.com/muesli/smartcrop",
 	"Version": "v0.0.0-20180228075044-f6ebaa786a12",
 	"Time": "2018-02-28T07:50:44Z",
+	"Indirect": true,
 	"Update": {
 		"Path": "github.com/muesli/smartcrop",
 		"Version": "v0.2.0",
 		"Time": "2017-08-09T19:13:04Z"
 	},
 	"GoMod": "/home/user/go/pkg/mod/cache/download/github.com/muesli/smartcrop/@v/v0.0.0-20180228075044-f6ebaa786a12.mod"
-}
-{
-	"Path": "github.com/markbates/inflect",
-	"Version": "v1.0.0",
-	"Replace": {
-		"Path": "github.com/markbates/inflect",
-		"Version": "v0.0.0-20171215194931-a12c3aec81a6",
-		"Time": "2017-12-15T19:49:31Z",
-		"Update": {
-			"Path": "github.com/markbates/inflect",
-			"Version": "v1.0.4",
-			"Time": "2018-10-24T20:35:00Z"
-		},
-		"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/markbates/inflect/@v/v0.0.0-20171215194931-a12c3aec81a6.mod"
-	},
-	"Update": {
-		"Path": "github.com/markbates/inflect",
-		"Version": "v1.0.4",
-		"Time": "2018-10-24T20:35:00Z"
-	},
-	"GoMod": "go.mod"
 }

--- a/internal/runner/testdata/update_indirect.txt
+++ b/internal/runner/testdata/update_indirect.txt
@@ -1,0 +1,77 @@
+{
+	"Path": "github.com/gohugoio/hugo",
+	"Main": true,
+	"Dir": "/home/mojo/Code/go/hugo",
+	"GoMod": "/home/mojo/Code/go/hugo/go.mod"
+}
+{
+	"Path": "github.com/BurntSushi/locker",
+	"Version": "v0.0.0-20171006230638-a6e239ea1c69",
+	"Time": "2017-10-06T23:06:38Z",
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/locker@v0.0.0-20171006230638-a6e239ea1c69",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/locker/@v/v0.0.0-20171006230638-a6e239ea1c69.mod"
+}
+{
+	"Path": "github.com/BurntSushi/toml",
+	"Version": "v0.0.0-20170626110600-a368813c5e64",
+	"Time": "2017-06-26T11:06:00Z",
+	"Update": {
+		"Path": "github.com/BurntSushi/toml",
+		"Version": "v0.3.1",
+		"Time": "2018-08-15T10:47:33Z"
+	},
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/toml@v0.0.0-20170626110600-a368813c5e64",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/toml/@v/v0.0.0-20170626110600-a368813c5e64.mod"
+}
+{
+	"Path": "github.com/PuerkitoBio/purell",
+	"Version": "v1.1.0",
+	"Time": "2016-11-15T02:49:42Z",
+	"Update": {
+		"Path": "github.com/PuerkitoBio/purell",
+		"Version": "v1.1.1",
+		"Time": "2019-02-16T21:19:35Z"
+	},
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.0",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/purell/@v/v1.1.0.mod"
+}
+{
+	"Path": "github.com/PuerkitoBio/urlesc",
+	"Version": "v0.0.0-20170810143723-de5bf2ad4578",
+	"Time": "2017-08-10T14:37:23Z",
+	"Indirect": true,
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/urlesc/@v/v0.0.0-20170810143723-de5bf2ad4578.mod"
+}
+{
+	"Path": "github.com/muesli/smartcrop",
+	"Version": "v0.0.0-20180228075044-f6ebaa786a12",
+	"Time": "2018-02-28T07:50:44Z",
+	"Update": {
+		"Path": "github.com/muesli/smartcrop",
+		"Version": "v0.2.0",
+		"Time": "2017-08-09T19:13:04Z"
+	},
+	"GoMod": "/home/user/go/pkg/mod/cache/download/github.com/muesli/smartcrop/@v/v0.0.0-20180228075044-f6ebaa786a12.mod"
+}
+{
+	"Path": "github.com/markbates/inflect",
+	"Version": "v1.0.0",
+	"Replace": {
+		"Path": "github.com/markbates/inflect",
+		"Version": "v0.0.0-20171215194931-a12c3aec81a6",
+		"Time": "2017-12-15T19:49:31Z",
+		"Update": {
+			"Path": "github.com/markbates/inflect",
+			"Version": "v1.0.4",
+			"Time": "2018-10-24T20:35:00Z"
+		},
+		"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/markbates/inflect/@v/v0.0.0-20171215194931-a12c3aec81a6.mod"
+	},
+	"Update": {
+		"Path": "github.com/markbates/inflect",
+		"Version": "v1.0.4",
+		"Time": "2018-10-24T20:35:00Z"
+	},
+	"GoMod": "go.mod"
+}

--- a/main.go
+++ b/main.go
@@ -12,9 +12,10 @@ func main() {
 
 	withUpdate := flag.Bool("update", false, "List only modules with updates")
 	onlyDirect := flag.Bool("direct", false, "List only direct modules")
+	exitNonZero := flag.Bool("ci", false, "Non-zero exit code when at least one outdated dependency was found")
 	flag.Parse()
 
-	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect)
+	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero)
 
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
This adds a flag "-ci", which will make go-mod-outdated to exit with a non zero exit code (1) when a outdated dependency is found.  