### PR TITLE
Add style parameter and markdown output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ If you want to see only the direct depedencies that have updates run
 go list -u -m -json all | go-mod-outdated -update -direct 
 ```
 
-To output a markdown compatible table, pass the `-markdown` flag
+To output a markdown compatible table, pass the `-style markdown` option
 
 ```
-go list -u -m -json all | go-mod-outdated -markdown 
+go list -u -m -json all | go-mod-outdated -style markdown 
 ```
 
 ### Docker
@@ -115,8 +115,8 @@ Usage of go-mod-outdated:
         List only modules with updates
   -ci
         Non-zero exit code when at least one outdated dependency was found
-  -markdown
-        Output Markdown compatible table
+  -style string
+        Output style, pass 'markdown' for a Markdown table (default "default")
 ```
 
 ### Shortcut

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ If you want to see only the direct depedencies that have updates run
 ```
 go list -u -m -json all | go-mod-outdated -update -direct 
 ```
+
+To output a markdown compatible table, pass the `-markdown` flag
+
+```
+go list -u -m -json all | go-mod-outdated -markdown 
+```
+
 ### Docker
 In the folder where your go.mod lives run
 ```
@@ -107,7 +114,9 @@ Usage of go-mod-outdated:
   -update
         List only modules with updates
   -ci
-        Exit with non-zero exit code when outdated dependencies are found
+        Non-zero exit code when at least one outdated dependency was found
+  -markdown
+        Output Markdown compatible table
 ```
 
 ### Shortcut

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,7 +16,7 @@ import (
 var OsExit = os.Exit
 
 // Run converts the the json output of go list -u -m -json all to table format
-func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero, markdown bool) error {
+func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, style string) error {
 	var modules []mod.Module
 
 	dec := json.NewDecoder(in)
@@ -28,7 +28,7 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero, markdown 
 		if err != nil {
 			if err == io.EOF {
 				filteredModules := mod.FilterModules(modules, update, direct)
-				renderTable(out, filteredModules, markdown)
+				renderTable(out, filteredModules, style)
 
 				if hasOutdated(filteredModules) && exitWithNonZero {
 					OsExit(1)
@@ -54,12 +54,12 @@ func hasOutdated(filteredModules []mod.Module) bool {
 	return false
 }
 
-func renderTable(writer io.Writer, modules []mod.Module, markdown bool) {
+func renderTable(writer io.Writer, modules []mod.Module, style string) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
 
-	// Render table as markdown if flag is set
-	if markdown {
+	// Render table as markdown
+	if style == "markdown" {
 		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 		table.SetCenterSeparator("|")
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,7 +16,7 @@ import (
 var OsExit = os.Exit
 
 // Run converts the the json output of go list -u -m -json all to table format
-func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) error {
+func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero, markdown bool) error {
 	var modules []mod.Module
 
 	dec := json.NewDecoder(in)
@@ -28,7 +28,7 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool) erro
 		if err != nil {
 			if err == io.EOF {
 				filteredModules := mod.FilterModules(modules, update, direct)
-				renderTable(out, filteredModules)
+				renderTable(out, filteredModules, markdown)
 
 				if hasOutdated(filteredModules) && exitWithNonZero {
 					OsExit(1)
@@ -54,9 +54,15 @@ func hasOutdated(filteredModules []mod.Module) bool {
 	return false
 }
 
-func renderTable(writer io.Writer, modules []mod.Module) {
+func renderTable(writer io.Writer, modules []mod.Module, markdown bool) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
+
+	// Render table as markdown if flag is set
+	if markdown {
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		table.SetCenterSeparator("|")
+	}
 
 	for k := range modules {
 		table.Append([]string{

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -10,35 +10,42 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	tests := []struct {
-		name     string
-		markdown bool
-		expected string
-	}{
-		{name: "ascii table", markdown: false, expected: "testdata/out.txt"},
-		{name: "markdown table", markdown: true, expected: "testdata/out.md"},
+	var gotOut bytes.Buffer
+
+	inBytes, _ := ioutil.ReadFile("testdata/in.txt")
+	in := bytes.NewBuffer(inBytes)
+
+	outBytes, _ := ioutil.ReadFile("testdata/out.txt")
+	wantOut := bytes.NewBuffer(outBytes)
+
+	err := runner.Run(in, &gotOut, false, false, false, false)
+
+	if err != nil {
+		t.Errorf("Error should be nil, got %s", err.Error())
 	}
-	//scopelint:ignore
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var gotOut bytes.Buffer
 
-			inBytes, _ := ioutil.ReadFile("testdata/in.txt")
-			in := bytes.NewBuffer(inBytes)
+	if !bytes.Equal(gotOut.Bytes(), wantOut.Bytes()) {
+		t.Errorf("Wanted \n%q, got \n%q", wantOut.String(), gotOut.String())
+	}
+}
 
-			outBytes, _ := ioutil.ReadFile(tt.expected)
-			wantOut := bytes.NewBuffer(outBytes)
+func TestRunMarkdown(t *testing.T) {
+	var gotOut bytes.Buffer
 
-			err := runner.Run(in, &gotOut, false, false, false, tt.markdown)
+	inBytes, _ := ioutil.ReadFile("testdata/in.txt")
+	in := bytes.NewBuffer(inBytes)
 
-			if err != nil {
-				t.Errorf("Error should be nil, got %s", err.Error())
-			}
+	outBytes, _ := ioutil.ReadFile("testdata/out.md")
+	wantOut := bytes.NewBuffer(outBytes)
 
-			if !bytes.Equal(gotOut.Bytes(), wantOut.Bytes()) {
-				t.Errorf("Wanted \n%q, got \n%q", wantOut.String(), gotOut.String())
-			}
-		})
+	err := runner.Run(in, &gotOut, false, false, false, true)
+
+	if err != nil {
+		t.Errorf("Error should be nil, got %s", err.Error())
+	}
+
+	if !bytes.Equal(gotOut.Bytes(), wantOut.Bytes()) {
+		t.Errorf("Wanted \n%q, got \n%q", wantOut.String(), gotOut.String())
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -18,6 +18,7 @@ func TestRun(t *testing.T) {
 		{name: "ascii table", markdown: false, expected: "testdata/out.txt"},
 		{name: "markdown table", markdown: true, expected: "testdata/out.md"},
 	}
+	//scopelint:ignore
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotOut bytes.Buffer

--- a/internal/runner/testdata/out.md
+++ b/internal/runner/testdata/out.md
@@ -1,0 +1,8 @@
+|            MODULE             |              VERSION               | NEW VERSION | DIRECT | VALID TIMESTAMPS |
+|-------------------------------|------------------------------------|-------------|--------|------------------|
+| github.com/BurntSushi/locker  | v0.0.0-20171006230638-a6e239ea1c69 |             | true   | true             |
+| github.com/BurntSushi/toml    | v0.0.0-20170626110600-a368813c5e64 | v0.3.1      | true   | true             |
+| github.com/PuerkitoBio/purell | v1.1.0                             | v1.1.1      | true   | true             |
+| github.com/PuerkitoBio/urlesc | v0.0.0-20170810143723-de5bf2ad4578 |             | false  | true             |
+| github.com/muesli/smartcrop   | v0.0.0-20180228075044-f6ebaa786a12 | v0.2.0      | true   | false            |
+| github.com/markbates/inflect  | v0.0.0-20171215194931-a12c3aec81a6 | v1.0.4      | true   | true             |

--- a/main.go
+++ b/main.go
@@ -13,9 +13,10 @@ func main() {
 	withUpdate := flag.Bool("update", false, "List only modules with updates")
 	onlyDirect := flag.Bool("direct", false, "List only direct modules")
 	exitNonZero := flag.Bool("ci", false, "Non-zero exit code when at least one outdated dependency was found")
+	markdown := flag.Bool("markdown", false, "Output Markdown compatible table")
 	flag.Parse()
 
-	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero)
+	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, *markdown)
 
 	if err != nil {
 		log.Print(err)

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ func main() {
 	withUpdate := flag.Bool("update", false, "List only modules with updates")
 	onlyDirect := flag.Bool("direct", false, "List only direct modules")
 	exitNonZero := flag.Bool("ci", false, "Non-zero exit code when at least one outdated dependency was found")
-	markdown := flag.Bool("markdown", false, "Output Markdown compatible table")
+	style := flag.String("style", "default", "Output style, pass 'markdown' for a Markdown table")
 	flag.Parse()
 
-	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, *markdown)
+	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, *style)
 
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
Hi,

Came across `go-mod-outdated` today and thought: Great idea!

Immediately tried it on our own Go project and wanted to post its results into our internal Gitlab Wiki (which supports Markdown syntax and tables).

This made me think, wouldn't it be nice if `go-mod-outdated` would support markdown compatible table output... I've added a `-markdown` flag in this pull request.

Not sure if it would be better to have a general `-style` parameter to pass a output style argument, for example:

```bash
go-mod-outdated -style <default|markdown|pretty>`
```

`pretty` could be a [coloured table output](https://github.com/olekukonko/tablewriter#table-with-color-output).

Let me know what you think and if you would want to support something like that.

Thanks for this great tool.

tsak