### PR TITLE
Skip rendering the table if there are no updates to display

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - gofumpt
     - gci
     - goerr113
+    - nestif
     - exhaustivestruct
     - paralleltest
     - errorlint

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,15 +15,15 @@ import (
 // OsExit is use here in order to simplify testing
 var OsExit = os.Exit
 
-type Style string
+type OutputStyle string
 
 const (
-	StyleDefault  Style = "default"
-	StyleMarkdown Style = "markdown"
+	StyleDefault  OutputStyle = "default"
+	StyleMarkdown OutputStyle = "markdown"
 )
 
 // Run converts the the json output of go list -u -m -json all to table format
-func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, style Style) error {
+func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, style OutputStyle) error {
 	var modules []mod.Module
 
 	dec := json.NewDecoder(in)
@@ -63,7 +63,7 @@ func hasOutdated(filteredModules []mod.Module) bool {
 	return false
 }
 
-func renderTable(writer io.Writer, modules []mod.Module, style Style) {
+func renderTable(writer io.Writer, modules []mod.Module, style OutputStyle) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -28,7 +28,9 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, styl
 		if err != nil {
 			if err == io.EOF {
 				filteredModules := mod.FilterModules(modules, update, direct)
-				renderTable(out, filteredModules, style)
+				if len(filteredModules) > 0 {
+					renderTable(out, filteredModules, style)
+				}
 
 				if hasOutdated(filteredModules) && exitWithNonZero {
 					OsExit(1)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,8 +15,15 @@ import (
 // OsExit is use here in order to simplify testing
 var OsExit = os.Exit
 
+type Style string
+
+const (
+	StyleDefault  Style = "default"
+	StyleMarkdown Style = "markdown"
+)
+
 // Run converts the the json output of go list -u -m -json all to table format
-func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, style string) error {
+func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, style Style) error {
 	var modules []mod.Module
 
 	dec := json.NewDecoder(in)
@@ -56,12 +63,12 @@ func hasOutdated(filteredModules []mod.Module) bool {
 	return false
 }
 
-func renderTable(writer io.Writer, modules []mod.Module, style string) {
+func renderTable(writer io.Writer, modules []mod.Module, style Style) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
 
 	// Render table as markdown
-	if style == "markdown" {
+	if style == StyleMarkdown {
 		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 		table.SetCenterSeparator("|")
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,10 +15,13 @@ import (
 // OsExit is use here in order to simplify testing
 var OsExit = os.Exit
 
+// OutputStyle specifies the supported table rendering formats
 type OutputStyle string
 
 const (
-	StyleDefault  OutputStyle = "default"
+	// StyleDefault represents the default output style
+	StyleDefault OutputStyle = "default"
+	// StyleMarkdown represents the markdown formatted output style
 	StyleMarkdown OutputStyle = "markdown"
 )
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -13,12 +13,12 @@ import (
 func TestRun(t *testing.T) {
 	tests := []struct {
 		name           string
-		style          runner.Style
+		style          runner.OutputStyle
 		expectedOutput string
 	}{
 		{name: "nil style", expectedOutput: "testdata/out.txt"},
 		{name: "default style", style: runner.StyleDefault, expectedOutput: "testdata/out.txt"},
-		{name: "non-existent style", style: runner.Style("foo"), expectedOutput: "testdata/out.txt"},
+		{name: "non-existent style", style: runner.OutputStyle("foo"), expectedOutput: "testdata/out.txt"},
 		{name: "markdown style", style: runner.StyleMarkdown, expectedOutput: "testdata/out.md"},
 	}
 
@@ -36,7 +36,7 @@ func TestRun(t *testing.T) {
 			err := runner.Run(in, &gotOut, false, false, false, tt.style)
 
 			if err != nil {
-				t.Errorf("Error should be nil, got %w", err)
+				t.Errorf("Error should be nil, got %s", err)
 			}
 
 			if !bytes.Equal(gotOut.Bytes(), wantOut.Bytes()) {
@@ -49,16 +49,16 @@ func TestRun(t *testing.T) {
 func TestRunNoUpdatesCase(t *testing.T) {
 	inBytes, err := ioutil.ReadFile("testdata/no_direct_updates.json")
 	if err != nil {
-		t.Errorf("Failed to read input file: %w", err)
+		t.Errorf("Failed to read input file: %s", err)
 	}
 	in := bytes.NewBuffer(inBytes)
-	var result bytes.Buffer
-	err = runner.Run(in, &result, true, true, false, runner.StyleDefault)
+	var out bytes.Buffer
+	err = runner.Run(in, &out, true, false, false, runner.StyleDefault)
 	if err != nil {
-		t.Errorf("Error should be nil, got %w", err)
+		t.Errorf("Error should be nil, got %s", err)
 	}
-	if result.Len() != 0 {
-		t.Errorf("Wanted an empty output, got \n%q", result.String())
+	if out.Len() != 0 {
+		t.Errorf("Wanted an empty output, got \n%q", out.String())
 	}
 }
 
@@ -71,7 +71,7 @@ func TestRunWithError(t *testing.T) {
 	err := runner.Run(in, &out, false, false, false, runner.StyleDefault)
 
 	if !errors.Is(err, io.ErrUnexpectedEOF) {
-		t.Errorf("Wanted an EOF error, got %w", err)
+		t.Errorf("Wanted an EOF error, got %s", err)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestRunExitWithNonZero(t *testing.T) {
 
 	err := runner.Run(in, &out, false, false, true, runner.StyleDefault)
 	if err != nil {
-		t.Errorf("Error should be nil, got %w", err)
+		t.Errorf("Error should be nil, got %s", err)
 	}
 
 	if exp := 1; got != exp {
@@ -123,7 +123,7 @@ func TestRunExitWithNonZeroIndirectsOnly(t *testing.T) {
 
 	err := runner.Run(in, &out, false, true, true, runner.StyleDefault)
 	if err != nil {
-		t.Errorf("Error should be nil, got %s", err.Error())
+		t.Errorf("Error should be nil, got %s", err)
 	}
 
 	if exp := 0; got != exp {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -51,12 +51,16 @@ func TestRunNoUpdatesCase(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to read input file: %s", err)
 	}
+
 	in := bytes.NewBuffer(inBytes)
+
 	var out bytes.Buffer
+
 	err = runner.Run(in, &out, true, false, false, runner.StyleDefault)
 	if err != nil {
 		t.Errorf("Error should be nil, got %s", err)
 	}
+
 	if out.Len() != 0 {
 		t.Errorf("Wanted an empty output, got \n%q", out.String())
 	}

--- a/internal/runner/testdata/no_direct_updates.json
+++ b/internal/runner/testdata/no_direct_updates.json
@@ -1,0 +1,21 @@
+{
+	"Path": "github.com/gohugoio/hugo",
+	"Main": true,
+	"Dir": "/home/mojo/Code/go/hugo",
+	"GoMod": "/home/mojo/Code/go/hugo/go.mod"
+}
+{
+	"Path": "github.com/BurntSushi/locker",
+	"Version": "v0.0.0-20171006230638-a6e239ea1c69",
+	"Time": "2017-10-06T23:06:38Z",
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/locker@v0.0.0-20171006230638-a6e239ea1c69",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/locker/@v/v0.0.0-20171006230638-a6e239ea1c69.mod"
+}
+{
+	"Path": "github.com/PuerkitoBio/urlesc",
+	"Version": "v0.0.0-20170810143723-de5bf2ad4578",
+	"Time": "2017-08-10T14:37:23Z",
+	"Indirect": true,
+	"Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+	"GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/urlesc/@v/v0.0.0-20170810143723-de5bf2ad4578.mod"
+}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 }
 
-func normalizeStyle(style string) runner.Style {
+func normalizeStyle(style string) runner.OutputStyle {
 	switch style {
 	case "markdown":
 		return runner.StyleMarkdown

--- a/main.go
+++ b/main.go
@@ -16,9 +16,18 @@ func main() {
 	style := flag.String("style", "default", "Output style, pass 'markdown' for a Markdown table")
 	flag.Parse()
 
-	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, *style)
+	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, normalizeStyle(*style))
 
 	if err != nil {
 		log.Print(err)
+	}
+}
+
+func normalizeStyle(style string) runner.Style {
+	switch style {
+	case "markdown":
+		return runner.StyleMarkdown
+	default:
+		return runner.StyleDefault
 	}
 }


### PR DESCRIPTION
In my usecase I'd like to only see output if there is an update to perform.
This change skips running the table rendering if the filtered modules is an empty slice.