### PR TITLE
Go version update to the latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
   docker:
     strategy:
       matrix:
-        go-version: [1.16.x]
-        platform: [ubuntu-latest]  
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
     name: docker
     runs-on: ${{ matrix.platform }}
     steps:
@@ -30,12 +30,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: |
           docker build -t psampaz/go-mod-outdated .
-          go list -u -m -json all | docker run --rm -i  psampaz/go-mod-outdated             
+          go list -u -m -json all | docker run --rm -i  psampaz/go-mod-outdated
   tests:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
-        platform: [ubuntu-latest, macos-latest]  
+        go-version: [1.16.x, 1.17.x]
+        platform: [ubuntu-latest, macos-latest]
     name: tests
     runs-on: ${{ matrix.platform }}
     steps:
@@ -48,17 +48,17 @@ jobs:
       - run: |
           go get github.com/mfridman/tparse
           go test -v -race -cover -json ./... | $(go env GOPATH)/bin/tparse -all
-      - run: |        
+      - run: |
           go install
-          mkdir hugo 
+          mkdir hugo
           cp internal/runner/testdata/hugo_0_53_go.mod hugo/go.mod
           cd hugo
-          go list -u -m -json all | $(go env GOPATH)/bin/go-mod-outdated    
+          go list -u -m -json all | $(go env GOPATH)/bin/go-mod-outdated
   coverage:
     strategy:
       matrix:
-        go-version: [1.16.x]
-        platform: [ubuntu-latest]  
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
     name: coverage
     runs-on: ${{ matrix.platform }}
     steps:
@@ -70,10 +70,10 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: |
           go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
-      - name: Upload coverage to Codecov  
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.txt
           flags: unittests
-          name: codecov-umbrella 
+          name: codecov-umbrella

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.13
+FROM golang:1.17.8-alpine3.15
 RUN apk add --no-cache git
 WORKDIR /home
 COPY ./ .

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/psampaz/go-mod-outdated
 
-go 1.14
+go 1.17
+
+require github.com/olekukonko/tablewriter v0.0.5
 
 require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rivo/uniseg v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Update Go version used to build [go-mod-outdated](https://github.com/psampaz/go-mod-outdated).