### PR TITLE
Allow to output JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [ΝΕΧΤ]  ΧΧΧΧ-ΧΧ-ΧΧ
 ### Added
+- Add `json` output style to produce the same JSON structure that was read from stdin, allowing `go-mod-outdated`
+  to be used as a shell filter ([#56](https://github.com/psampaz/go-mod-outdated/pull/56))
 
 ### Changed
 - Skip rendering the table if there are no updates to display https://github.com/psampaz/go-mod-outdated/pull/46
@@ -44,7 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Reduced docker image size
 - Updated version of golangci-lint to 1.24
 
-## [0.5.0] 2019-09-27 
+## [0.5.0] 2019-09-27
 ### Added
 - Run tests on Go 1.13
 
@@ -68,7 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [0.2.0] - 2019-04-22
 ### Added
 - Extra column 'VALID TIMESTAMPS' which indicates if the timestamp of the new version is
-actually newer that the current one 
+actually newer that the current one
 
 ### Changed
 - Packages are now internal

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ into this
 go get -u github.com/psampaz/go-mod-outdated
 ```
 
-or 
+or
 
 ```go
 go install github.com/psampaz/go-mod-outdated@v0.8.0
@@ -58,14 +58,14 @@ if you are on go 1.16
 
 ## Usage
 In the folder where your go.mod lives run
- 
+
 ```
 go list -u -m -json all | go-mod-outdated
 ```
 
 to see all modules in table view.
 
-If you want to see only the modules with updates run 
+If you want to see only the modules with updates run
 
 ```
 go list -u -m -json all | go-mod-outdated -update
@@ -80,23 +80,30 @@ go list -u -m -json all | go-mod-outdated -direct
 If you want to see only the direct depedencies that have updates run
 
 ```
-go list -u -m -json all | go-mod-outdated -update -direct 
+go list -u -m -json all | go-mod-outdated -update -direct
 ```
 
 To output a markdown compatible table, pass the `-style markdown` option
 
 ```
-go list -u -m -json all | go-mod-outdated -style markdown 
+go list -u -m -json all | go-mod-outdated -style markdown
+```
+
+If you need to postprocess the filtered list of modules and updates, you can use `-style json`
+to output the same JSON structure as `go list` produced.
+
+```
+go list -u -m -json all | go-mod-outdated -style json
 ```
 
 **Important note for Go 1.14 users**
 
-If are using Go 1.14 with vendoring you need to pass **-mod=mod** or **-mod=readonly** to the go list command otherwise 
-you will get the following error: 
+If are using Go 1.14 with vendoring you need to pass **-mod=mod** or **-mod=readonly** to the go list command otherwise
+you will get the following error:
 
 ```
 $ go list -u -m -json all
- 
+
 go list -m: can't determine available upgrades using the vendor directory
         (Use -mod=mod or -mod=readonly to bypass.)
 ```
@@ -133,7 +140,7 @@ If you want to make your CI pipeline fail **only if a direct** dependency is out
 go list -u -m -json all | go-mod-outdated -direct -ci
 ```
 ### Help
-  
+
 In order to see details about the usage of the command use the **-h** or **-help** flag
 
 ```
@@ -152,8 +159,8 @@ Usage of go-mod-outdated:
 
 ### Shortcut
 
-If **go list -u -m -json all | go-mod-outdated -update -direct** seems too difficult to use or remember you can create 
-a shortcut using an alias. In linux try one of the following: 
+If **go list -u -m -json all | go-mod-outdated -update -direct** seems too difficult to use or remember you can create
+a shortcut using an alias. In linux try one of the following:
 
 ```
 alias gmo="go list -u -m -json all | go-mod-outdated"
@@ -163,20 +170,20 @@ alias gmod="go list -u -m -json all | go-mod-outdated -direct"
 alias gmou="go list -u -m -json all | go-mod-outdated -update"
 
 alias gmodu="go list -u -m -json all | go-mod-outdated -direct -update"
-```  
+```
 
 ## Invalid timestamps
 
-There is a case where the updated version reported by the go list command is actually older than the current one.  
- 
+There is a case where the updated version reported by the go list command is actually older than the current one.
+
 go-mod-outdated output includes a column named **VALID TIMESTAMP** which will give an indication when this case happens,
-helping application maintainers to avoid upgrading to a version that will break their application. 
+helping application maintainers to avoid upgrading to a version that will break their application.
 
 ## Important note
 
 - Upgrading an application is a responsibility of the maintainer of the application. Semantic versioning provides a way
 to indicate breaking changes, but still everything relies on each module developer to apply correct version tags. Unless
-there is a fully automated way to detect breaking changes in a codebase, a good practice to avoid surpises is to write 
+there is a fully automated way to detect breaking changes in a codebase, a good practice to avoid surpises is to write
 tests and avoid dependencies on modules not well maintained and documented.
 
 
@@ -188,14 +195,14 @@ tests and avoid dependencies on modules not well maintained and documented.
 
 ## Supported operating systems
 
-- linux 
+- linux
 - osx
 
 ## Real Example
 
 The following example is based on Hugo's go.mod (v0.53) (https://raw.githubusercontent.com/gohugoio/hugo/v0.53/go.mod)
 
-### Json output of go list -u -m json all command    
+### Json output of go list -u -m json all command
 
 ```
 $ go list -u -m -json all

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -23,6 +23,8 @@ const (
 	StyleDefault OutputStyle = "default"
 	// StyleMarkdown represents the markdown formatted output style
 	StyleMarkdown OutputStyle = "markdown"
+	// StyleJSON represents the JSON formatted output style
+	StyleJSON OutputStyle = "json"
 )
 
 // Run converts the the json output of go list -u -m -json all to table format
@@ -39,7 +41,7 @@ func Run(in io.Reader, out io.Writer, update, direct, exitWithNonZero bool, styl
 			if err == io.EOF {
 				filteredModules := mod.FilterModules(modules, update, direct)
 				if len(filteredModules) > 0 {
-					renderTable(out, filteredModules, style)
+					renderOutput(out, filteredModules, style)
 				}
 
 				if hasOutdated(filteredModules) && exitWithNonZero {
@@ -66,6 +68,14 @@ func hasOutdated(filteredModules []mod.Module) bool {
 	return false
 }
 
+func renderOutput(writer io.Writer, modules []mod.Module, style OutputStyle) {
+	if style == StyleJSON {
+		renderJSON(writer, modules)
+	} else {
+		renderTable(writer, modules, style)
+	}
+}
+
 func renderTable(writer io.Writer, modules []mod.Module, style OutputStyle) {
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Module", "Version", "New Version", "Direct", "Valid Timestamps"})
@@ -87,4 +97,11 @@ func renderTable(writer io.Writer, modules []mod.Module, style OutputStyle) {
 	}
 
 	table.Render()
+}
+
+func renderJSON(writer io.Writer, modules []mod.Module) {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+
+	encoder.Encode(modules)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -20,6 +20,7 @@ func TestRun(t *testing.T) {
 		{name: "default style", style: runner.StyleDefault, expectedOutput: "testdata/out.txt"},
 		{name: "non-existent style", style: runner.OutputStyle("foo"), expectedOutput: "testdata/out.txt"},
 		{name: "markdown style", style: runner.StyleMarkdown, expectedOutput: "testdata/out.md"},
+		{name: "JSON style", style: runner.StyleJSON, expectedOutput: "testdata/out.json"},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/testdata/out.json
+++ b/internal/runner/testdata/out.json
@@ -1,0 +1,73 @@
+[
+  {
+    "Path": "github.com/BurntSushi/locker",
+    "Version": "v0.0.0-20171006230638-a6e239ea1c69",
+    "Time": "2017-10-06T23:06:38Z",
+    "Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/locker@v0.0.0-20171006230638-a6e239ea1c69",
+    "GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/locker/@v/v0.0.0-20171006230638-a6e239ea1c69.mod"
+  },
+  {
+    "Path": "github.com/BurntSushi/toml",
+    "Version": "v0.0.0-20170626110600-a368813c5e64",
+    "Time": "2017-06-26T11:06:00Z",
+    "Update": {
+      "Path": "github.com/BurntSushi/toml",
+      "Version": "v0.3.1",
+      "Time": "2018-08-15T10:47:33Z"
+    },
+    "Dir": "/home/mojo/go/pkg/mod/github.com/!burnt!sushi/toml@v0.0.0-20170626110600-a368813c5e64",
+    "GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!burnt!sushi/toml/@v/v0.0.0-20170626110600-a368813c5e64.mod"
+  },
+  {
+    "Path": "github.com/PuerkitoBio/purell",
+    "Version": "v1.1.0",
+    "Time": "2016-11-15T02:49:42Z",
+    "Update": {
+      "Path": "github.com/PuerkitoBio/purell",
+      "Version": "v1.1.1",
+      "Time": "2019-02-16T21:19:35Z"
+    },
+    "Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.0",
+    "GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/purell/@v/v1.1.0.mod"
+  },
+  {
+    "Path": "github.com/PuerkitoBio/urlesc",
+    "Version": "v0.0.0-20170810143723-de5bf2ad4578",
+    "Time": "2017-08-10T14:37:23Z",
+    "Indirect": true,
+    "Dir": "/home/mojo/go/pkg/mod/github.com/!puerkito!bio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+    "GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/!puerkito!bio/urlesc/@v/v0.0.0-20170810143723-de5bf2ad4578.mod"
+  },
+  {
+    "Path": "github.com/muesli/smartcrop",
+    "Version": "v0.0.0-20180228075044-f6ebaa786a12",
+    "Time": "2018-02-28T07:50:44Z",
+    "Update": {
+      "Path": "github.com/muesli/smartcrop",
+      "Version": "v0.2.0",
+      "Time": "2017-08-09T19:13:04Z"
+    },
+    "GoMod": "/home/user/go/pkg/mod/cache/download/github.com/muesli/smartcrop/@v/v0.0.0-20180228075044-f6ebaa786a12.mod"
+  },
+  {
+    "Path": "github.com/markbates/inflect",
+    "Version": "v1.0.0",
+    "Replace": {
+      "Path": "github.com/markbates/inflect",
+      "Version": "v0.0.0-20171215194931-a12c3aec81a6",
+      "Time": "2017-12-15T19:49:31Z",
+      "Update": {
+        "Path": "github.com/markbates/inflect",
+        "Version": "v1.0.4",
+        "Time": "2018-10-24T20:35:00Z"
+      },
+      "GoMod": "/home/mojo/go/pkg/mod/cache/download/github.com/markbates/inflect/@v/v0.0.0-20171215194931-a12c3aec81a6.mod"
+    },
+    "Update": {
+      "Path": "github.com/markbates/inflect",
+      "Version": "v1.0.4",
+      "Time": "2018-10-24T20:35:00Z"
+    },
+    "GoMod": "go.mod"
+  }
+]

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 	withUpdate := flag.Bool("update", false, "List only modules with updates")
 	onlyDirect := flag.Bool("direct", false, "List only direct modules")
 	exitNonZero := flag.Bool("ci", false, "Non-zero exit code when at least one outdated dependency was found")
-	style := flag.String("style", "default", "Output style, pass 'markdown' for a Markdown table")
+	style := flag.String("style", "default", "Output style, pass 'markdown' for a Markdown table or 'json' for JSON")
 	flag.Parse()
 
 	err := runner.Run(os.Stdin, os.Stdout, *withUpdate, *onlyDirect, *exitNonZero, normalizeStyle(*style))

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func normalizeStyle(style string) runner.OutputStyle {
 	switch style {
 	case "markdown":
 		return runner.StyleMarkdown
+	case "json":
+		return runner.StyleJSON
 	default:
 		return runner.StyleDefault
 	}


### PR DESCRIPTION
This adds a new output style, `json`, that outputs the same JSON that the tool ingests as its input, allowing it to work as a "filter" of sorts and enabling people to visualize the result the way they like it.